### PR TITLE
Fix Excessive setting, Feature Interface Spacing

### DIFF
--- a/shared/java/top/fpsmaster/features/impl/InterfaceModule.java
+++ b/shared/java/top/fpsmaster/features/impl/InterfaceModule.java
@@ -16,6 +16,8 @@ public class InterfaceModule extends Module {
     public BooleanSetting fontShadow = new BooleanSetting("FontShadow", true, () -> betterFont.getValue());
     public BooleanSetting bg = new BooleanSetting("Background", true);
     public ColorSetting backgroundColor = new ColorSetting("BackgroundColor", new Color(0, 0, 0, 0), () -> bg.getValue());
+    public NumberSetting spacing = new NumberSetting("Spacing",0,0,3,1);
+
 
     public InterfaceModule(String name, Category category) {
         super(name, category);

--- a/shared/java/top/fpsmaster/features/impl/interfaces/Keystrokes.java
+++ b/shared/java/top/fpsmaster/features/impl/interfaces/Keystrokes.java
@@ -3,6 +3,7 @@ package top.fpsmaster.features.impl.interfaces;
 import top.fpsmaster.features.impl.InterfaceModule;
 import top.fpsmaster.features.manager.Category;
 import top.fpsmaster.features.settings.impl.ColorSetting;
+import top.fpsmaster.features.settings.impl.NumberSetting;
 
 import java.awt.*;
 
@@ -11,6 +12,6 @@ public class Keystrokes extends InterfaceModule {
 
     public Keystrokes() {
         super("Keystrokes", Category.Interface);
-        addSettings(rounded, backgroundColor, fontShadow, betterFont, pressedColor, bg, rounded, roundRadius);
+        addSettings(fontShadow, betterFont, pressedColor, spacing, bg, backgroundColor, rounded, roundRadius);
     }
 }

--- a/shared/java/top/fpsmaster/ui/custom/impl/KeystrokesComponent.java
+++ b/shared/java/top/fpsmaster/ui/custom/impl/KeystrokesComponent.java
@@ -29,6 +29,25 @@ public class KeystrokesComponent extends Component {
     public void draw(float x, float y) {
         super.draw(x, y);
         for (Key key : keys) {
+            switch (key.keyCode) {
+                case Keyboard.KEY_W:
+                    key.yOffset = key.defaultYOffset - mod.spacing.getValue().intValue();
+                    break;
+                case Keyboard.KEY_A:
+                    key.xOffset = key.defaultXOffset - mod.spacing.getValue().intValue();
+                    break;
+                case Keyboard.KEY_D:
+                    key.xOffset = key.defaultXOffset + mod.spacing.getValue().intValue();
+                    break;
+                case -1:
+                    key.xOffset = key.defaultXOffset - mod.spacing.getValue().intValue();
+                    key.yOffset = key.defaultYOffset + mod.spacing.getValue().intValue();
+                    break;
+                case -2:
+                    key.xOffset = key.defaultXOffset + mod.spacing.getValue().intValue();
+                    key.yOffset = key.defaultYOffset + mod.spacing.getValue().intValue();
+                    break;
+            }
             key.render(x, y, 0f, mod.backgroundColor.getColor(), Keystrokes.pressedColor.getColor());
         }
         width = 60f;
@@ -38,16 +57,20 @@ public class KeystrokesComponent extends Component {
     public class Key {
         private final String name;
         private final int keyCode;
-        private final int xOffset;
-        private final int yOffset;
+        private final int defaultXOffset;
+        private final int defaultYOffset;
+        private int xOffset;
+        private int yOffset;
         private final ColorAnimation color;
 
         public Key(String name, int keyCode, int xOffset, int yOffset) {
             this.name = name;
             this.keyCode = keyCode;
-            this.xOffset = xOffset;
-            this.yOffset = yOffset;
+            this.defaultXOffset = xOffset;
+            this.defaultYOffset = yOffset;
             this.color = new ColorAnimation();
+            this.xOffset = defaultXOffset;
+            this.yOffset = defaultYOffset;
         }
 
         public void render(float x, float y, float speed, Color color, Color color1) {

--- a/shared/resources/assets/minecraft/client/lang/en_us.lang
+++ b/shared/resources/assets/minecraft/client/lang/en_us.lang
@@ -113,6 +113,7 @@ keystrokes.fontshadow=Font Shadow
 keystrokes.betterfont=Clean Font
 keystrokes.roundradius=Corner Radius
 keystrokes.background=Show Background
+keystrokes.spacing=Spacing
 
 potiondisplay=Potion HUD
 potiondisplay.desc=Displays active potion effects

--- a/shared/resources/assets/minecraft/client/lang/zh_cn.lang
+++ b/shared/resources/assets/minecraft/client/lang/zh_cn.lang
@@ -113,6 +113,7 @@ keystrokes.fontshadow=字体阴影
 keystrokes.betterfont=更好的字体
 keystrokes.roundradius=圆角半径
 keystrokes.background=背景
+keystrokes.spacing=间距
 
 potiondisplay=药水显示
 potiondisplay.desc=显示玩家的药水效果


### PR DESCRIPTION
I fix a bug about keystroke excessive rounded setting
<img width="1048" height="44" alt="af1bd4e4-0879-4411-9d69-9fa49533a4d7" src="https://github.com/user-attachments/assets/ae1db680-7691-4238-8b1f-3debda5de150" />
I add a spacing setting for interface module to improve customizability

https://github.com/user-attachments/assets/cc7dc999-ed10-4444-98d3-d1b7c52e8a0d
> Thanks 🫠