### PR TITLE
New item count component and item multiple setting

### DIFF
--- a/shared/java/top/fpsmaster/features/impl/interfaces/ItemCountDisplay.java
+++ b/shared/java/top/fpsmaster/features/impl/interfaces/ItemCountDisplay.java
@@ -3,15 +3,18 @@ package top.fpsmaster.features.impl.interfaces;
 import top.fpsmaster.features.impl.InterfaceModule;
 import top.fpsmaster.features.manager.Category;
 import top.fpsmaster.features.settings.impl.ModeSetting;
+import top.fpsmaster.features.settings.impl.MutipleItemSetting;
 
 public class ItemCountDisplay extends InterfaceModule {
 
     //TODO: Custom 自定义物品数量，建议添加MultipleSetting，便于让用户自动添加，暂未实现
-    public ModeSetting mode = new ModeSetting("mode",0,"potpvp","uhc","custom");
+    public ModeSetting modes = new ModeSetting("mode", 0, "potpvp", "uhc", "custom");
+
+    public MutipleItemSetting itemsSetting = new MutipleItemSetting("items",() -> modes.getValue() == 2);
 
     public ItemCountDisplay() {
         super("ItemCountDisplay", Category.Interface);
-        addSettings(mode, bg, backgroundColor, rounded, roundRadius, betterFont, fontShadow, spacing);
+        addSettings(bg, backgroundColor ,rounded, roundRadius, betterFont, fontShadow, spacing, modes, itemsSetting);
     }
 
 }

--- a/shared/java/top/fpsmaster/features/impl/interfaces/ItemCountDisplay.java
+++ b/shared/java/top/fpsmaster/features/impl/interfaces/ItemCountDisplay.java
@@ -1,0 +1,17 @@
+package top.fpsmaster.features.impl.interfaces;
+
+import top.fpsmaster.features.impl.InterfaceModule;
+import top.fpsmaster.features.manager.Category;
+import top.fpsmaster.features.settings.impl.ModeSetting;
+
+public class ItemCountDisplay extends InterfaceModule {
+
+    //TODO: Custom 自定义物品数量，建议添加MultipleSetting，便于让用户自动添加，暂未实现
+    public ModeSetting mode = new ModeSetting("mode",0,"potpvp","uhc","custom");
+
+    public ItemCountDisplay() {
+        super("ItemCountDisplay", Category.Interface);
+        addSettings(mode, bg, backgroundColor, rounded, roundRadius, betterFont, fontShadow, spacing);
+    }
+
+}

--- a/shared/java/top/fpsmaster/features/impl/interfaces/ItemCountDisplay.java
+++ b/shared/java/top/fpsmaster/features/impl/interfaces/ItemCountDisplay.java
@@ -3,14 +3,14 @@ package top.fpsmaster.features.impl.interfaces;
 import top.fpsmaster.features.impl.InterfaceModule;
 import top.fpsmaster.features.manager.Category;
 import top.fpsmaster.features.settings.impl.ModeSetting;
-import top.fpsmaster.features.settings.impl.MutipleItemSetting;
+import top.fpsmaster.features.settings.impl.MultipleItemSetting;
 
 public class ItemCountDisplay extends InterfaceModule {
 
     //TODO: Custom 自定义物品数量，建议添加MultipleSetting，便于让用户自动添加，暂未实现
     public ModeSetting modes = new ModeSetting("mode", 0, "potpvp", "uhc", "custom");
 
-    public MutipleItemSetting itemsSetting = new MutipleItemSetting("items",() -> modes.getValue() == 2);
+    public MultipleItemSetting itemsSetting = new MultipleItemSetting("items",() -> modes.getValue() == 2);
 
     public ItemCountDisplay() {
         super("ItemCountDisplay", Category.Interface);

--- a/shared/java/top/fpsmaster/features/impl/utility/AutoGG.java
+++ b/shared/java/top/fpsmaster/features/impl/utility/AutoGG.java
@@ -20,10 +20,10 @@ public class AutoGG extends Module {
     public BooleanSetting autoPlay = new BooleanSetting("AutoPlay", false);
     public NumberSetting delay = new NumberSetting("DelayToPlay", 5, 0, 10, 1, () -> autoPlay.getValue());
     public TextSetting message = new TextSetting("Message", "gg");
-    public ModeSetting servers = new ModeSetting("Servers", 0, "hypxiel");
+    public ModeSetting servers = new ModeSetting("Servers", 0, "hypxiel", "kkcraft");
 
     public String hypixelTrigger = "Reward Summary;1st Killer;Damage Dealt;奖励总览;击杀数第一名;造成伤害";
-
+    public String kkcraftTrigger = "获胜者;第一名杀手;击杀第一名";
     public AutoGG() {
         super("AutoGG", Category.Utility);
         this.addSettings(autoPlay, delay, message, servers);
@@ -32,12 +32,13 @@ public class AutoGG extends Module {
     @Subscribe
     public void onPacket(EventPacket event) {
         if (event.type == EventPacket.PacketType.RECEIVE && ProviderManager.packetChat.isPacket(event.packet)) {
+            String componentValue = ProviderManager.packetChat.getChatComponent(event.packet).toString();
+            String chatMessage = ProviderManager.packetChat.getUnformattedText(event.packet);
+            boolean hasEndInformation = false;
+            Utility.sendClientMessage(componentValue);
             switch (servers.getValue()) {
                 case 0:
-                    String componentValue = ProviderManager.packetChat.getChatComponent(event.packet).toString();
                     boolean hasPlayCommand = componentValue.contains("ClickEvent{action=RUN_COMMAND, value='/play ");
-                    String chatMessage = ProviderManager.packetChat.getUnformattedText(event.packet);
-                    boolean hasEndInformation = false;
                     for (String s : hypixelTrigger.split(";")) {
                         hasEndInformation = StringUtils.stripControlCodes(chatMessage).contains(s);
                         if (hasEndInformation) break;
@@ -57,6 +58,18 @@ public class AutoGG extends Module {
                                 Utility.sendChatMessage(componentValue.substring(componentValue.indexOf("value='") + 7, componentValue.indexOf("'}")));
                             });
                         }
+                    }
+                    break;
+                case 1:
+                    for (String s : kkcraftTrigger.split(";")) {
+                        hasEndInformation = StringUtils.stripControlCodes(chatMessage).contains(s);
+                        if (hasEndInformation) break;
+                    }
+                    if (hasEndInformation) {
+                        Utility.sendChatMessage(message.getValue());
+                    }
+                    if(autoPlay.getValue()) {
+                        Utility.sendClientNotify("AutoPlay is not supported at the moment in KKCraft");
                     }
                     break;
                 default:

--- a/shared/java/top/fpsmaster/features/manager/Module.java
+++ b/shared/java/top/fpsmaster/features/manager/Module.java
@@ -48,6 +48,8 @@ public class Module {
                     this.settings.add(setting);
                 } else if (setting instanceof ColorSetting) {
                     this.settings.add(setting);
+                } else if (setting instanceof MutipleItemSetting) {
+                    this.settings.add(setting);
                 }
             }
         }

--- a/shared/java/top/fpsmaster/features/manager/Module.java
+++ b/shared/java/top/fpsmaster/features/manager/Module.java
@@ -48,7 +48,7 @@ public class Module {
                     this.settings.add(setting);
                 } else if (setting instanceof ColorSetting) {
                     this.settings.add(setting);
-                } else if (setting instanceof MutipleItemSetting) {
+                } else if (setting instanceof MultipleItemSetting) {
                     this.settings.add(setting);
                 }
             }

--- a/shared/java/top/fpsmaster/features/manager/ModuleManager.java
+++ b/shared/java/top/fpsmaster/features/manager/ModuleManager.java
@@ -13,7 +13,6 @@ import top.fpsmaster.features.impl.utility.*;
 import top.fpsmaster.interfaces.ProviderManager;
 import top.fpsmaster.modules.dev.DevMode;
 import top.fpsmaster.modules.logger.ClientLogger;
-import top.fpsmaster.ui.click.CosmeticScreen;
 import top.fpsmaster.ui.click.MainPanel;
 import top.fpsmaster.ui.click.modules.ModuleRenderer;
 import top.fpsmaster.ui.devspace.DevSpace;
@@ -123,7 +122,7 @@ public class ModuleManager {
         modules.add(new DirectionDisplay());
         modules.add(new DamageIndicator());
         modules.add(new TabOverlay());
-
+        modules.add(new ItemCountDisplay());
 
         if (ProviderManager.constants.getVersion().equals("1.12.2")) {
             modules.add(new HideIndicator());

--- a/shared/java/top/fpsmaster/features/settings/Setting.java
+++ b/shared/java/top/fpsmaster/features/settings/Setting.java
@@ -6,7 +6,7 @@ import top.fpsmaster.event.events.EventValueChange;
 public class Setting<T> {
 
     public String name;
-    T value;
+    public T value;
     public VisibleCondition visible;
 
     public Setting(String name, T value) {

--- a/shared/java/top/fpsmaster/features/settings/impl/MultipleItemSetting.java
+++ b/shared/java/top/fpsmaster/features/settings/impl/MultipleItemSetting.java
@@ -5,13 +5,13 @@ import top.fpsmaster.features.settings.Setting;
 
 import java.util.ArrayList;
 
-public class MutipleItemSetting extends Setting<ArrayList<ItemStack>> {
+public class MultipleItemSetting extends Setting<ArrayList<ItemStack>> {
     public static final int MAX_CAPACITY = 7;
-    public MutipleItemSetting(String name) {
+    public MultipleItemSetting(String name) {
         super(name, new ArrayList<>());
     }
 
-    public MutipleItemSetting(String name, VisibleCondition condition) {
+    public MultipleItemSetting(String name, VisibleCondition condition) {
         super(name, new ArrayList<>(), condition);
     }
 

--- a/shared/java/top/fpsmaster/features/settings/impl/MutipleItemSetting.java
+++ b/shared/java/top/fpsmaster/features/settings/impl/MutipleItemSetting.java
@@ -1,0 +1,29 @@
+package top.fpsmaster.features.settings.impl;
+
+import net.minecraft.item.ItemStack;
+import top.fpsmaster.features.settings.Setting;
+
+import java.util.ArrayList;
+
+public class MutipleItemSetting extends Setting<ArrayList<ItemStack>> {
+    public static final int MAX_CAPACITY = 7;
+    public MutipleItemSetting(String name) {
+        super(name, new ArrayList<>());
+    }
+
+    public MutipleItemSetting(String name, VisibleCondition condition) {
+        super(name, new ArrayList<>(), condition);
+    }
+
+    public void addItem(ItemStack itemStack) {
+        if (this.getValue().size() < MAX_CAPACITY) {
+            this.getValue().add(itemStack);
+        }
+    }
+
+    public void removeItem(int index) {
+        ItemStack itemStack = this.getValue().get(index);
+        this.getValue().remove(itemStack);
+    }
+
+}

--- a/shared/java/top/fpsmaster/modules/config/ConfigManager.java
+++ b/shared/java/top/fpsmaster/modules/config/ConfigManager.java
@@ -1,9 +1,8 @@
 package top.fpsmaster.modules.config;
 
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
-import com.google.gson.JsonElement;
-import com.google.gson.JsonObject;
+import com.google.gson.*;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
 import top.fpsmaster.FPSMaster;
 import top.fpsmaster.exception.FileException;
 import top.fpsmaster.features.impl.optimizes.OldAnimations;
@@ -17,8 +16,9 @@ import top.fpsmaster.features.settings.impl.utils.CustomColor;
 import top.fpsmaster.ui.custom.Component;
 import top.fpsmaster.ui.custom.Position;
 import top.fpsmaster.utils.os.FileUtils;
+import top.fpsmaster.utils.world.ItemsUtil;
 
-import java.util.Map;
+import java.util.*;
 
 public class ConfigManager {
 
@@ -80,6 +80,18 @@ public class ConfigManager {
             moduleJson.addProperty("enabled", module.isEnabled());
             moduleJson.addProperty("key", module.key);
             for (Setting<?> setting : module.settings) {
+                if(setting instanceof MutipleItemSetting) {
+                    MutipleItemSetting mutipleItemSetting = (MutipleItemSetting) setting;
+                    ArrayList<ItemStack> value = mutipleItemSetting.getValue();
+                    List<String> items = new ArrayList<>();
+                    value.forEach((itemStack)->{
+                        items.add(Item.getIdFromItem(itemStack.getItem()) + "|" + itemStack.getMetadata());
+                    });
+                    JsonElement jsonTree = gson.toJsonTree(items);
+                    moduleJson.add(setting.name, jsonTree);
+                    continue;
+                }
+
                 String settingValue = setting.getValue().toString();
                 if (setting instanceof ColorSetting) {
                     ColorSetting colorSetting = (ColorSetting) setting;
@@ -140,6 +152,15 @@ public class ConfigManager {
                         } else if (setting instanceof BindSetting) {
                             BindSetting bindSetting = (BindSetting) setting;
                             bindSetting.setValue(settingValue.getAsInt());
+                        } else if (setting instanceof MutipleItemSetting) {
+                            MutipleItemSetting mutipleItemSetting = (MutipleItemSetting) setting;
+                            String[] itemInfoList = gson.fromJson(settingValue.getAsJsonArray(), String[].class);
+                            for (String itemStack : itemInfoList) {
+                                String[] item = itemStack.split("\\|");
+                                int id = Integer.parseInt(item[0]);
+                                int metadata = Integer.parseInt(item[1]);
+                                mutipleItemSetting.addItem(ItemsUtil.getItemStackWithMetadata(Item.getItemById(id),metadata));
+                            }
                         }
                     }
                 }

--- a/shared/java/top/fpsmaster/modules/config/ConfigManager.java
+++ b/shared/java/top/fpsmaster/modules/config/ConfigManager.java
@@ -80,9 +80,9 @@ public class ConfigManager {
             moduleJson.addProperty("enabled", module.isEnabled());
             moduleJson.addProperty("key", module.key);
             for (Setting<?> setting : module.settings) {
-                if(setting instanceof MutipleItemSetting) {
-                    MutipleItemSetting mutipleItemSetting = (MutipleItemSetting) setting;
-                    ArrayList<ItemStack> value = mutipleItemSetting.getValue();
+                if(setting instanceof MultipleItemSetting) {
+                    MultipleItemSetting multipleItemSetting = (MultipleItemSetting) setting;
+                    ArrayList<ItemStack> value = multipleItemSetting.getValue();
                     List<String> items = new ArrayList<>();
                     value.forEach((itemStack)->{
                         items.add(Item.getIdFromItem(itemStack.getItem()) + "|" + itemStack.getMetadata());
@@ -152,14 +152,14 @@ public class ConfigManager {
                         } else if (setting instanceof BindSetting) {
                             BindSetting bindSetting = (BindSetting) setting;
                             bindSetting.setValue(settingValue.getAsInt());
-                        } else if (setting instanceof MutipleItemSetting) {
-                            MutipleItemSetting mutipleItemSetting = (MutipleItemSetting) setting;
+                        } else if (setting instanceof MultipleItemSetting) {
+                            MultipleItemSetting multipleItemSetting = (MultipleItemSetting) setting;
                             String[] itemInfoList = gson.fromJson(settingValue.getAsJsonArray(), String[].class);
                             for (String itemStack : itemInfoList) {
                                 String[] item = itemStack.split("\\|");
                                 int id = Integer.parseInt(item[0]);
                                 int metadata = Integer.parseInt(item[1]);
-                                mutipleItemSetting.addItem(ItemsUtil.getItemStackWithMetadata(Item.getItemById(id),metadata));
+                                multipleItemSetting.addItem(ItemsUtil.getItemStackWithMetadata(Item.getItemById(id),metadata));
                             }
                         }
                     }

--- a/shared/java/top/fpsmaster/ui/click/MainPanel.java
+++ b/shared/java/top/fpsmaster/ui/click/MainPanel.java
@@ -12,7 +12,6 @@ import top.fpsmaster.features.manager.Module;
 import top.fpsmaster.ui.ai.AIChatPanel;
 import top.fpsmaster.ui.click.component.ScrollContainer;
 import top.fpsmaster.ui.click.modules.ModuleRenderer;
-import top.fpsmaster.ui.click.music.MusicPanel;
 import top.fpsmaster.ui.click.music.NewMusicPanel;
 import top.fpsmaster.utils.math.animation.Animation;
 import top.fpsmaster.utils.math.animation.AnimationUtils;
@@ -52,7 +51,7 @@ public class MainPanel extends ScaledGuiScreen {
     static int y = -1;
     static float width = 430f;
     static float height = 245.5f;
-    final float leftWidth = 50f;
+    public static final float leftWidth = 50f;
     public static String bindLock = "";
     public static Module curModule = null;
     public static String dragLock = "null";

--- a/shared/java/top/fpsmaster/ui/click/modules/ModuleRenderer.java
+++ b/shared/java/top/fpsmaster/ui/click/modules/ModuleRenderer.java
@@ -28,22 +28,24 @@ public class ModuleRenderer extends ValueRender {
     ColorAnimation option = new ColorAnimation();
     float optionX = 0;
 
-    public ModuleRenderer(Module mod) {
-        this.mod = mod;
-        content = new ColorAnimation(mod.isEnabled() ? new Color(66, 66, 66) : new Color(40, 40, 40));
-        mod.settings.forEach(setting -> {
+    public ModuleRenderer(Module module) {
+        this.mod = module;
+        content = new ColorAnimation(module.isEnabled() ? new Color(66, 66, 66) : new Color(40, 40, 40));
+        module.settings.forEach(setting -> {
             if (setting instanceof BooleanSetting) {
-                settingsRenderers.add(new BooleanSettingRender(mod, (BooleanSetting) setting));
+                settingsRenderers.add(new BooleanSettingRender(module, (BooleanSetting) setting));
             } else if (setting instanceof ModeSetting) {
-                settingsRenderers.add(new ModeSettingRender(mod, (ModeSetting) setting));
+                settingsRenderers.add(new ModeSettingRender(module, (ModeSetting) setting));
             } else if (setting instanceof TextSetting) {
-                settingsRenderers.add(new TextSettingRender(mod, (TextSetting) setting));
+                settingsRenderers.add(new TextSettingRender(module, (TextSetting) setting));
             } else if (setting instanceof NumberSetting) {
-                settingsRenderers.add(new NumberSettingRender(mod, (NumberSetting) setting));
+                settingsRenderers.add(new NumberSettingRender(module, (NumberSetting) setting));
             } else if (setting instanceof ColorSetting) {
-                settingsRenderers.add(new ColorSettingRender(mod, (ColorSetting) setting));
+                settingsRenderers.add(new ColorSettingRender(module, (ColorSetting) setting));
             } else if (setting instanceof BindSetting) {
-                settingsRenderers.add(new BindSettingRender(mod, (BindSetting) setting));
+                settingsRenderers.add(new BindSettingRender(module, (BindSetting) setting));
+            } else if(setting instanceof  MutipleItemSetting) {
+                settingsRenderers.add(new MultipleItemSettingRender(module,(MutipleItemSetting)setting));
             }
         });
     }

--- a/shared/java/top/fpsmaster/ui/click/modules/ModuleRenderer.java
+++ b/shared/java/top/fpsmaster/ui/click/modules/ModuleRenderer.java
@@ -44,8 +44,8 @@ public class ModuleRenderer extends ValueRender {
                 settingsRenderers.add(new ColorSettingRender(module, (ColorSetting) setting));
             } else if (setting instanceof BindSetting) {
                 settingsRenderers.add(new BindSettingRender(module, (BindSetting) setting));
-            } else if(setting instanceof  MutipleItemSetting) {
-                settingsRenderers.add(new MultipleItemSettingRender(module,(MutipleItemSetting)setting));
+            } else if(setting instanceof MultipleItemSetting) {
+                settingsRenderers.add(new MultipleItemSettingRender(module,(MultipleItemSetting)setting));
             }
         });
     }

--- a/shared/java/top/fpsmaster/ui/click/modules/impl/MultipleItemSettingRender.java
+++ b/shared/java/top/fpsmaster/ui/click/modules/impl/MultipleItemSettingRender.java
@@ -1,0 +1,82 @@
+package top.fpsmaster.ui.click.modules.impl;
+
+import net.minecraft.item.ItemStack;
+import top.fpsmaster.FPSMaster;
+import top.fpsmaster.features.manager.Module;
+import top.fpsmaster.features.settings.impl.MutipleItemSetting;
+import top.fpsmaster.interfaces.ProviderManager;
+import top.fpsmaster.ui.click.modules.SettingRender;
+import top.fpsmaster.utils.render.Render2DUtils;
+import top.fpsmaster.utils.world.ItemsUtil;
+
+import java.awt.*;
+import java.util.Locale;
+
+public class MultipleItemSettingRender extends SettingRender<MutipleItemSetting> {
+    public static final int xOffset = 14;
+    public static final int padding = 3;
+    public static final int itemHeight = 21;
+    public static final int buttonSize = 15;
+
+    public MultipleItemSettingRender(Module module, MutipleItemSetting setting) {
+        super(setting);
+        this.mod = module;
+    }
+    private float itemWidth;
+    @Override
+    public void render(float x, float y, float width, float height, float mouseX, float mouseY, boolean custom) {
+        FPSMaster.fontManager.s16.drawString(
+                FPSMaster.i18n.get((mod.name + "." + setting.name).toLowerCase(Locale.getDefault())),
+                x + xOffset, y + 1, new Color(162, 162, 162).getRGB()
+        );
+        Render2DUtils.drawOptimizedRoundedRect(x + xOffset, y + FPSMaster.fontManager.s16.getHeight() + 5, itemWidth + padding, this.height - 7, 3, new Color(80, 80, 80, 160).getRGB());
+        int textWidth = FPSMaster.fontManager.s14.getStringWidth(FPSMaster.i18n.get(FPSMaster.i18n.get("ItemsSetting.heldItem".toLowerCase(Locale.getDefault()))));
+        FPSMaster.fontManager.s14.drawString(FPSMaster.i18n.get("ItemsSetting.heldItem".toLowerCase(Locale.getDefault())), x + xOffset + itemWidth - 30 - textWidth, y + 1, -1) ;
+        FPSMaster.fontManager.s22.drawString("+", x + xOffset + itemWidth - 12, y + 1, -1);
+
+        Render2DUtils.drawOptimizedRoundedRect(x + xOffset, y + FPSMaster.fontManager.s16.getHeight() + 5, itemWidth + padding, this.height - 7, 3, new Color(80, 80, 80, 160).getRGB());
+
+        int index = 0;
+        this.itemWidth = width - (xOffset * 2);
+        for (ItemStack itemStack : setting.getValue()) {
+            Render2DUtils.drawOptimizedRoundedRect(x + xOffset + padding, y + FPSMaster.fontManager.s16.getHeight() + 5 + padding + (index * (itemHeight + padding)), itemWidth - padding, itemHeight, new Color(50, 50, 50, 120));
+            ItemsUtil.renderItem(itemStack, x + (padding * 2) + 20f, (y + FPSMaster.fontManager.s16.getHeight() + 5 + padding * 2) + (index * (itemHeight + padding)));
+            renderButton(x + xOffset + itemWidth - (padding * 2) - buttonSize, (y + FPSMaster.fontManager.s16.getHeight() + 5 + padding * 2) + (index * (buttonSize + (padding * 3))), mouseX,mouseY ,"-");
+            FPSMaster.fontManager.s14.drawString(itemStack.getDisplayName(), x + (padding * 2) + 45f, (y + FPSMaster.fontManager.s16.getHeight() + 5 + padding * 2) + (index * (buttonSize + (padding * 3))) + 5, -1);
+            index++;
+        }
+        if(setting.getValue().isEmpty()){
+            this.height = itemHeight + 10;
+            FPSMaster.fontManager.s14.drawString(FPSMaster.i18n.get("ItemsSetting.isEmpty".toLowerCase(Locale.getDefault())), x + ((itemWidth - (padding * 2)) / 2), (y + FPSMaster.fontManager.s16.getHeight() + 5 + padding * 2) + 5, -1);
+        }else{
+            this.height = (index * (itemHeight + padding)) + 10;
+        }
+
+    }
+
+    public void renderButton(float x, float y, float mouseX, float mouseY, String icon) {
+        Color color = new Color(70, 70, 70, 140);
+        if(Render2DUtils.isHovered(x,y,buttonSize,buttonSize,(int) mouseX,(int) mouseY)){
+            color = new Color(120, 120, 120, 140);
+        }
+        Render2DUtils.drawOptimizedRoundedRect(x, y, buttonSize, buttonSize, color);
+        FPSMaster.fontManager.s16.drawString(icon, x + (buttonSize / 2.0f) - 2, y + (buttonSize / 2.0f) - 6, -1);
+    }
+
+    @Override
+    public void mouseClick(float x, float y, float width, float height, float mouseX, float mouseY, int btn) {
+        if(Render2DUtils.isHovered(x + 10 + xOffset + itemWidth - 15, y - 3,10,10,(int)mouseX,(int)mouseY) && btn == 0){
+            ItemStack heldItem = ProviderManager.mcProvider.getPlayer().getHeldItem();
+            if(heldItem != null){
+                this.setting.addItem(heldItem);
+                return;
+            }
+        }
+        //TODO: 转为使用迭代器Iterator实现
+        for (int index = 0; index < setting.getValue().size(); index++) {
+            if (Render2DUtils.isHovered(x + 10 + xOffset + itemWidth - (padding * 2) - buttonSize, (y + FPSMaster.fontManager.s16.getHeight() + 5 + padding * 2) + (index * (buttonSize + (padding * 3))), buttonSize, buttonSize, (int) mouseX, (int) mouseY) && btn == 0) {
+                this.setting.removeItem(index);
+            }
+        }
+    }
+}

--- a/shared/java/top/fpsmaster/ui/click/modules/impl/MultipleItemSettingRender.java
+++ b/shared/java/top/fpsmaster/ui/click/modules/impl/MultipleItemSettingRender.java
@@ -3,7 +3,7 @@ package top.fpsmaster.ui.click.modules.impl;
 import net.minecraft.item.ItemStack;
 import top.fpsmaster.FPSMaster;
 import top.fpsmaster.features.manager.Module;
-import top.fpsmaster.features.settings.impl.MutipleItemSetting;
+import top.fpsmaster.features.settings.impl.MultipleItemSetting;
 import top.fpsmaster.interfaces.ProviderManager;
 import top.fpsmaster.ui.click.modules.SettingRender;
 import top.fpsmaster.utils.render.Render2DUtils;
@@ -12,13 +12,13 @@ import top.fpsmaster.utils.world.ItemsUtil;
 import java.awt.*;
 import java.util.Locale;
 
-public class MultipleItemSettingRender extends SettingRender<MutipleItemSetting> {
+public class MultipleItemSettingRender extends SettingRender<MultipleItemSetting> {
     public static final int xOffset = 14;
     public static final int padding = 3;
     public static final int itemHeight = 21;
     public static final int buttonSize = 15;
 
-    public MultipleItemSettingRender(Module module, MutipleItemSetting setting) {
+    public MultipleItemSettingRender(Module module, MultipleItemSetting setting) {
         super(setting);
         this.mod = module;
     }

--- a/shared/java/top/fpsmaster/ui/custom/ComponentsManager.java
+++ b/shared/java/top/fpsmaster/ui/custom/ComponentsManager.java
@@ -37,6 +37,7 @@ public class ComponentsManager {
         components.add(new ModsListComponent());
         components.add(new MiniMapComponent());
         components.add(new SprintComponent());
+        components.add(new ItemCountDisplayComponent());
     }
 
     // Get a component by its class type

--- a/shared/java/top/fpsmaster/ui/custom/impl/ItemCountDisplayComponent.java
+++ b/shared/java/top/fpsmaster/ui/custom/impl/ItemCountDisplayComponent.java
@@ -1,0 +1,94 @@
+package top.fpsmaster.ui.custom.impl;
+
+import net.minecraft.client.renderer.GlStateManager;
+import net.minecraft.client.renderer.RenderHelper;
+import net.minecraft.init.Items;
+import net.minecraft.item.ItemStack;
+import net.minecraft.potion.Potion;
+import top.fpsmaster.features.impl.interfaces.ItemCountDisplay;
+import top.fpsmaster.interfaces.ProviderManager;
+import top.fpsmaster.ui.custom.Component;
+import top.fpsmaster.utils.world.ItemsUtil;
+import top.fpsmaster.utils.world.PotionMetadata;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.Collectors;
+
+import static top.fpsmaster.utils.Utility.mc;
+
+public class ItemCountDisplayComponent extends Component {
+
+    private static final float DISPLAY_HEIGHT = 27;
+    private static final float ITEM_WIDTH = 17;
+    public Map<Integer, ItemStack[]> modeItems = new HashMap<>();
+
+    public ItemCountDisplayComponent() {
+        super(ItemCountDisplay.class);
+        modeItems.put(0,
+                new ItemStack[]{
+                        ItemsUtil.getItemStack(Items.ender_pearl),
+                        ItemsUtil.getItemStackWithMetadata(Items.potionitem, PotionMetadata.SPLASH_HEALING_II),
+                        ItemsUtil.getItemStackWithMetadata(Items.potionitem, PotionMetadata.SPEED_II)
+                });
+        modeItems.put(1,
+                new ItemStack[]{
+                        ItemsUtil.getItemStack(Items.golden_apple),
+                        ItemsUtil.getItemStack(Items.arrow),
+                });
+        modeItems.put(2,
+                new ItemStack[]{});
+//        allowScale = true;
+    }
+
+    @Override
+    public void draw(float x, float y) {
+        super.draw(x, y);
+        ItemCountDisplay displayModule = ((ItemCountDisplay) mod);
+        ItemStack[] itemStacks = ProviderManager.mcProvider.getPlayer().inventory.mainInventory;
+        int index = 0;
+        for (ItemStack itemStack : modeItems.get(displayModule.mode.getValue())) {
+            AtomicLong count = new AtomicLong();
+            Arrays.stream(itemStacks)
+                    .filter((stack) -> {
+                        if (stack == null) {
+                            return false;
+                        }
+                        return stack.getItem() == itemStack.getItem() && stack.getMetadata() == itemStack.getMetadata();
+                    })
+                    .collect(Collectors.toList())
+                    .forEach((stack) -> count.addAndGet(stack.stackSize));
+            float xOffset = x + index * (ITEM_WIDTH + mod.spacing.getValue().intValue());
+            float textOffset = xOffset + 8f - (getStringWidth(20,String.valueOf(count)) / 2);
+            drawRect(xOffset,y,ITEM_WIDTH,DISPLAY_HEIGHT, mod.backgroundColor.getColor());
+            renderItem(itemStack, xOffset, y);
+            drawString(20, String.valueOf(count), textOffset, y + ITEM_WIDTH, -1);
+            index++;
+        }
+        width = index * (ITEM_WIDTH + mod.spacing.getValue().intValue());
+        height = DISPLAY_HEIGHT;
+    }
+
+    public void renderItem(ItemStack itemStack, float x, float y) {
+        GlStateManager.pushMatrix();
+        GlStateManager.disableCull();
+        GlStateManager.disableBlend();
+        GlStateManager.color(1.0F, 1.0F, 1.0F, 1.0F);
+
+        GlStateManager.enableRescaleNormal();
+        GlStateManager.enableBlend();
+        GlStateManager.tryBlendFuncSeparate(770, 771, 1, 0);
+        RenderHelper.enableGUIStandardItemLighting();
+        GlStateManager.pushMatrix();
+        mc.getRenderItem().renderItemIntoGUI(itemStack, (int) x, (int) y);
+        GlStateManager.popMatrix();
+        mc.getRenderItem().renderItemOverlays(ProviderManager.mcProvider.getFontRenderer(), itemStack, (int) x, (int) y);
+
+        RenderHelper.disableStandardItemLighting();
+        GlStateManager.disableRescaleNormal();
+        GlStateManager.disableBlend();
+        GlStateManager.popMatrix();
+    }
+}

--- a/shared/java/top/fpsmaster/ui/custom/impl/ItemCountDisplayComponent.java
+++ b/shared/java/top/fpsmaster/ui/custom/impl/ItemCountDisplayComponent.java
@@ -11,9 +11,7 @@ import top.fpsmaster.ui.custom.Component;
 import top.fpsmaster.utils.world.ItemsUtil;
 import top.fpsmaster.utils.world.PotionMetadata;
 
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.*;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
 
@@ -24,7 +22,7 @@ public class ItemCountDisplayComponent extends Component {
     private static final float DISPLAY_HEIGHT = 27;
     private static final float ITEM_WIDTH = 17;
     public Map<Integer, ItemStack[]> modeItems = new HashMap<>();
-
+    private List<ItemStack> itemStacks = new ArrayList<>();
     public ItemCountDisplayComponent() {
         super(ItemCountDisplay.class);
         modeItems.put(0,
@@ -38,20 +36,21 @@ public class ItemCountDisplayComponent extends Component {
                         ItemsUtil.getItemStack(Items.golden_apple),
                         ItemsUtil.getItemStack(Items.arrow),
                 });
-        modeItems.put(2,
-                new ItemStack[]{});
-//        allowScale = true;
+
     }
 
     @Override
     public void draw(float x, float y) {
         super.draw(x, y);
         ItemCountDisplay displayModule = ((ItemCountDisplay) mod);
-        ItemStack[] itemStacks = ProviderManager.mcProvider.getPlayer().inventory.mainInventory;
+        ItemStack[] mainInventory = ProviderManager.mcProvider.getPlayer().inventory.mainInventory;
+
+        if(displayModule.modes.getValue() != 2) itemStacks = Arrays.stream(modeItems.get(displayModule.modes.getValue())).collect(Collectors.toList());
+        else itemStacks = displayModule.itemsSetting.getValue();
         int index = 0;
-        for (ItemStack itemStack : modeItems.get(displayModule.mode.getValue())) {
+        for (ItemStack itemStack : itemStacks) {
             AtomicLong count = new AtomicLong();
-            Arrays.stream(itemStacks)
+            Arrays.stream(mainInventory)
                     .filter((stack) -> {
                         if (stack == null) {
                             return false;
@@ -63,7 +62,7 @@ public class ItemCountDisplayComponent extends Component {
             float xOffset = x + index * (ITEM_WIDTH + mod.spacing.getValue().intValue());
             float textOffset = xOffset + 8f - (getStringWidth(20,String.valueOf(count)) / 2);
             drawRect(xOffset,y,ITEM_WIDTH,DISPLAY_HEIGHT, mod.backgroundColor.getColor());
-            renderItem(itemStack, xOffset, y);
+            ItemsUtil.renderItem(itemStack, xOffset, y);
             drawString(20, String.valueOf(count), textOffset, y + ITEM_WIDTH, -1);
             index++;
         }
@@ -71,24 +70,5 @@ public class ItemCountDisplayComponent extends Component {
         height = DISPLAY_HEIGHT;
     }
 
-    public void renderItem(ItemStack itemStack, float x, float y) {
-        GlStateManager.pushMatrix();
-        GlStateManager.disableCull();
-        GlStateManager.disableBlend();
-        GlStateManager.color(1.0F, 1.0F, 1.0F, 1.0F);
 
-        GlStateManager.enableRescaleNormal();
-        GlStateManager.enableBlend();
-        GlStateManager.tryBlendFuncSeparate(770, 771, 1, 0);
-        RenderHelper.enableGUIStandardItemLighting();
-        GlStateManager.pushMatrix();
-        mc.getRenderItem().renderItemIntoGUI(itemStack, (int) x, (int) y);
-        GlStateManager.popMatrix();
-        mc.getRenderItem().renderItemOverlays(ProviderManager.mcProvider.getFontRenderer(), itemStack, (int) x, (int) y);
-
-        RenderHelper.disableStandardItemLighting();
-        GlStateManager.disableRescaleNormal();
-        GlStateManager.disableBlend();
-        GlStateManager.popMatrix();
-    }
 }

--- a/shared/java/top/fpsmaster/ui/custom/impl/LyricsComponent.java
+++ b/shared/java/top/fpsmaster/ui/custom/impl/LyricsComponent.java
@@ -12,7 +12,9 @@ import top.fpsmaster.utils.math.animation.AnimationUtils;
 import top.fpsmaster.utils.math.animation.Type;
 import top.fpsmaster.utils.render.Render2DUtils;
 
+import java.awt.*;
 import java.util.List;
+import java.util.Objects;
 
 public class LyricsComponent extends Component {
 
@@ -23,6 +25,7 @@ public class LyricsComponent extends Component {
         y = 0.2f;
         height = 70f;
         position = Position.CT;
+        allowScale = true;
     }
 
     private long fromTimeTick(String timeTick) {
@@ -43,6 +46,7 @@ public class LyricsComponent extends Component {
         }else{
             y += 5;
         }
+        y += (scale - 1) * 23;
         AbstractMusic current = NewMusicPanel.playing;
         if (current != null && current.lyrics != null) {
             int curLine = -1;
@@ -77,22 +81,23 @@ public class LyricsComponent extends Component {
                         Line line = lines.get(j);
                         String content = line.getContent();
                         float stringWidth = getStringWidth(20, content);
-                        float xOffset = x + (width - stringWidth) / 2;
+                        float xOffset = x + (width - stringWidth) / 2 * scale ;
                         width = 200f;
-                        if (this.width < stringWidth + 10) {
-                            this.width = stringWidth + 10;
+
+                        if (this.width < stringWidth + 10 ) {
+                            this.width = stringWidth + 10 ;
                         }
                         if (j == curLine) {
-                            line.animation = (float) AnimationUtils.base(line.animation, 0.0, 0.1f);
-                            line.alpha = (float) AnimationUtils.base(line.alpha, 1.0, 0.1f);
+                            line.animation = (float) AnimationUtils.base(line.animation, 0.0, 0.05f);
+                            line.alpha = (float) AnimationUtils.base(line.alpha, 1.0, 0.05f);
                         } else {
-                            line.animation = (float) AnimationUtils.base(line.animation, j - curLine, 0.1f);
+                            line.animation = (float) AnimationUtils.base(line.animation, j - curLine, 0.05f);
                             line.alpha = (float) (Math.abs(j - curLine) == 1 ?
-                                    AnimationUtils.base(line.alpha, 1.0, 0.1f) :
-                                    AnimationUtils.base(line.alpha, 0.0, 0.1f));
+                                    AnimationUtils.base(line.alpha, 1.0, 0.05f) :
+                                    AnimationUtils.base(line.alpha, 0.0, 0.05f));
                         }
                         if (Math.abs(j - curLine) <= 1) {
-                            drawLine(line, xOffset, y + line.animation * 20 + 20, 20,j == curLine);
+                            drawLine(line, xOffset, y + line.animation * (20 * scale)+ 20, 20,j == curLine);
                         }
                     }
                 }
@@ -113,7 +118,8 @@ public class LyricsComponent extends Component {
             }
             line.scaleAnimation.update();
             scaleRatio = (float) line.scaleAnimation.value;
-            Render2DUtils.scaleStart(xOffset + (getStringWidth(20, line.getContent()) / 2.0f), y + (getStringHeight(20) / 2.0f), scaleRatio);
+
+            Render2DUtils.scaleStart(xOffset + (getStringWidth((int) (20 * scale), line.getContent()) / 2.0f), y + (getStringHeight(20) / 2.0f), scaleRatio);
             GL11.glTranslated(0, -8, 0);
         }
         for (Word word : line.words) {
@@ -136,12 +142,12 @@ public class LyricsComponent extends Component {
             drawString(20, word.content, xOffset, y + 7,
                     Render2DUtils.reAlpha(LyricsDisplay.textColor.getColor(), (int) Math.min(line.alpha * 120, 255)).getRGB());
         }
-        return getStringWidth(20, word.content);
+        return getStringWidth(20, word.content) * scale;
     }
 
     private float drawWordBG(Word word, float xOffset, float y, Line line) {
         drawString(20, word.content, xOffset, y + 5,
                 Render2DUtils.reAlpha(LyricsDisplay.textBG.getColor(), (int) Math.min(line.alpha * 120, 255)).getRGB());
-        return getStringWidth(20, word.content);
+        return getStringWidth(20, word.content) * scale;
     }
 }

--- a/shared/java/top/fpsmaster/utils/Utility.java
+++ b/shared/java/top/fpsmaster/utils/Utility.java
@@ -5,6 +5,8 @@ import top.fpsmaster.interfaces.ProviderManager;
 import top.fpsmaster.modules.dev.DevMode;
 
 import java.util.ArrayList;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
 
 public class Utility {
 
@@ -46,4 +48,24 @@ public class Utility {
         }
         messages.clear();
     }
+    /**
+     * withIndex实现streamAPI foreach循环附带index <br />
+     * 用法:
+     * <code>
+     * list.stream().forEach(Utility.withIndex((item,index)->{
+     *      ...
+     * }))
+     * </code>
+     */
+    public static <T> Consumer<T> withIndex(BiConsumer<T, Integer> biConsumer) {
+        class IncrementInt{
+            int i = 0;
+            public int getAndIncrement(){
+                return i++;
+            }
+        }
+        IncrementInt incrementInt = new IncrementInt();
+        return t -> biConsumer.accept(t, incrementInt.getAndIncrement());
+    }
+
 }

--- a/shared/java/top/fpsmaster/utils/world/PotionMetadata.java
+++ b/shared/java/top/fpsmaster/utils/world/PotionMetadata.java
@@ -1,0 +1,206 @@
+package top.fpsmaster.utils.world; // 替换为你的mod包名
+
+import net.minecraft.potion.Potion; // 用于 Potion.heal.id 等
+import java.util.HashMap;
+import java.util.Map;
+
+
+public class PotionMetadata {
+
+    public static final int SPLASH_POTION_COMMON_OFFSET = 16384; // 0x4000
+    public static final int WATER_BOTTLE = 0;
+
+    public static final int HEALING_I = 8197;
+    public static final int HEALING_II = 8261;
+
+    public static final int HARMING_I = 8260;
+    public static final int HARMING_II = 8204;
+
+    public static final int SPEED_I = 8258;
+    public static final int SPEED_II = 8226;
+
+    public static final int SLOWNESS_I = 8202;
+
+    public static final int STRENGTH_I = 8265;
+    public static final int STRENGTH_II = 8201;
+
+    public static final int NIGHT_VISION_I = 8262;
+
+    public static final int INVISIBILITY_I = 8230;
+
+    public static final int POISON_I = 8264;
+    public static final int POISON_II = 8200;
+
+    public static final int REGENERATION_I = 8257;
+    public static final int REGENERATION_II = 8225;
+
+    public static final int FIRE_RESISTANCE_I = 8259;
+
+    public static final int WATER_BREATHING_I = 8231;
+
+    public static final int WEAKNESS_I = 8232;
+
+    public static final int LEAPING_I = 8235;
+    public static final int LEAPING_II = 8203;
+
+    public static final int SPLASH_WATER_BOTTLE = 16384;
+
+    public static final int SPLASH_HEALING_I = 16388;
+    public static final int SPLASH_HEALING_II = 16421;
+
+    public static final int SPLASH_HARMING_I = 16420;
+    public static final int SPLASH_HARMING_II = 16364;
+
+    public static final int SPLASH_SPEED_I = 16418;
+    public static final int SPLASH_SPEED_II = 16386;
+
+    public static final int SPLASH_SLOWNESS_I = 16362;
+
+    public static final int SPLASH_STRENGTH_I = 16425;
+    public static final int SPLASH_STRENGTH_II = 16361;
+
+    public static final int SPLASH_NIGHT_VISION_I = 16422;
+
+    public static final int SPLASH_INVISIBILITY_I = 16390;
+
+    public static final int SPLASH_POISON_I = 16424;
+    public static final int SPLASH_POISON_II = 16360;
+
+    public static final int SPLASH_REGENERATION_I = 16417;
+    public static final int SPLASH_REGENERATION_II = 16385;
+
+    public static final int SPLASH_FIRE_RESISTANCE_I = 16419;
+
+    public static final int SPLASH_WATER_BREATHING_I = 16391;
+
+    public static final int SPLASH_WEAKNESS_I = 16392;
+
+    public static final int SPLASH_LEAPING_I = 16395;
+    public static final int SPLASH_LEAPING_II = 16363;
+
+    private static final Map<Integer, Map<Boolean, Integer>> basePotionMetadataMap = new HashMap<>();
+    private static final Map<Integer, Map<Boolean, Integer>> splashPotionMetadataMap = new HashMap<>();
+
+    static {
+        Map<Boolean, Integer> healingMap = new HashMap<>();
+        healingMap.put(false, HEALING_I);
+        healingMap.put(true, HEALING_II);
+        basePotionMetadataMap.put(Potion.heal.id, healingMap);
+
+        Map<Boolean, Integer> harmingMap = new HashMap<>();
+        harmingMap.put(false, HARMING_I);
+        harmingMap.put(true, HARMING_II);
+        basePotionMetadataMap.put(Potion.harm.id, harmingMap);
+
+        Map<Boolean, Integer> speedMap = new HashMap<>();
+        speedMap.put(false, SPEED_I);
+        speedMap.put(true, SPEED_II);
+        basePotionMetadataMap.put(Potion.moveSpeed.id, speedMap);
+
+        Map<Boolean, Integer> slownessMap = new HashMap<>();
+        slownessMap.put(false, SLOWNESS_I); // Slowness usually no II
+        basePotionMetadataMap.put(Potion.moveSlowdown.id, slownessMap);
+
+        Map<Boolean, Integer> strengthMap = new HashMap<>();
+        strengthMap.put(false, STRENGTH_I);
+        strengthMap.put(true, STRENGTH_II);
+        basePotionMetadataMap.put(Potion.damageBoost.id, strengthMap);
+
+        Map<Boolean, Integer> nightVisionMap = new HashMap<>();
+        nightVisionMap.put(false, NIGHT_VISION_I);
+        basePotionMetadataMap.put(Potion.nightVision.id, nightVisionMap);
+
+        Map<Boolean, Integer> invisibilityMap = new HashMap<>();
+        invisibilityMap.put(false, INVISIBILITY_I);
+        basePotionMetadataMap.put(Potion.invisibility.id, invisibilityMap);
+
+        Map<Boolean, Integer> poisonMap = new HashMap<>();
+        poisonMap.put(false, POISON_I);
+        poisonMap.put(true, POISON_II);
+        basePotionMetadataMap.put(Potion.poison.id, poisonMap);
+
+        Map<Boolean, Integer> regenerationMap = new HashMap<>();
+        regenerationMap.put(false, REGENERATION_I);
+        regenerationMap.put(true, REGENERATION_II);
+        basePotionMetadataMap.put(Potion.regeneration.id, regenerationMap);
+
+        Map<Boolean, Integer> fireResistanceMap = new HashMap<>();
+        fireResistanceMap.put(false, FIRE_RESISTANCE_I);
+        basePotionMetadataMap.put(Potion.fireResistance.id, fireResistanceMap);
+
+        Map<Boolean, Integer> waterBreathingMap = new HashMap<>();
+        waterBreathingMap.put(false, WATER_BREATHING_I);
+        basePotionMetadataMap.put(Potion.waterBreathing.id, waterBreathingMap);
+
+        Map<Boolean, Integer> weaknessMap = new HashMap<>();
+        weaknessMap.put(false, WEAKNESS_I);
+        basePotionMetadataMap.put(Potion.weakness.id, weaknessMap);
+
+        Map<Boolean, Integer> leapingMap = new HashMap<>();
+        leapingMap.put(false, LEAPING_I);
+        leapingMap.put(true, LEAPING_II);
+        basePotionMetadataMap.put(Potion.jump.id, leapingMap);
+
+        // 初始化可喷溅药水映射
+        Map<Boolean, Integer> splashHealingMap = new HashMap<>();
+        splashHealingMap.put(false, SPLASH_HEALING_I);
+        splashHealingMap.put(true, SPLASH_HEALING_II);
+        splashPotionMetadataMap.put(Potion.heal.id, splashHealingMap);
+
+        Map<Boolean, Integer> splashHarmingMap = new HashMap<>();
+        splashHarmingMap.put(false, SPLASH_HARMING_I);
+        splashHarmingMap.put(true, SPLASH_HARMING_II);
+        splashPotionMetadataMap.put(Potion.harm.id, splashHarmingMap);
+
+        Map<Boolean, Integer> splashSpeedMap = new HashMap<>();
+        splashSpeedMap.put(false, SPLASH_SPEED_I);
+        splashSpeedMap.put(true, SPLASH_SPEED_II);
+        splashPotionMetadataMap.put(Potion.moveSpeed.id, splashSpeedMap);
+
+        Map<Boolean, Integer> splashSlownessMap = new HashMap<>();
+        splashSlownessMap.put(false, SPLASH_SLOWNESS_I);
+        splashPotionMetadataMap.put(Potion.moveSlowdown.id, splashSlownessMap);
+
+        Map<Boolean, Integer> splashStrengthMap = new HashMap<>();
+        splashStrengthMap.put(false, SPLASH_STRENGTH_I);
+        splashStrengthMap.put(true, SPLASH_STRENGTH_II);
+        splashPotionMetadataMap.put(Potion.damageBoost.id, splashStrengthMap);
+
+        Map<Boolean, Integer> splashNightVisionMap = new HashMap<>();
+        splashNightVisionMap.put(false, SPLASH_NIGHT_VISION_I);
+        splashPotionMetadataMap.put(Potion.nightVision.id, splashNightVisionMap);
+
+        Map<Boolean, Integer> splashInvisibilityMap = new HashMap<>();
+        splashInvisibilityMap.put(false, SPLASH_INVISIBILITY_I);
+        splashPotionMetadataMap.put(Potion.invisibility.id, splashInvisibilityMap);
+
+        Map<Boolean, Integer> splashPoisonMap = new HashMap<>();
+        splashPoisonMap.put(false, SPLASH_POISON_I);
+        splashPoisonMap.put(true, SPLASH_POISON_II);
+        splashPotionMetadataMap.put(Potion.poison.id, splashPoisonMap);
+
+        Map<Boolean, Integer> splashRegenerationMap = new HashMap<>();
+        splashRegenerationMap.put(false, SPLASH_REGENERATION_I);
+        splashRegenerationMap.put(true, SPLASH_REGENERATION_II);
+        splashPotionMetadataMap.put(Potion.regeneration.id, splashRegenerationMap);
+
+        Map<Boolean, Integer> splashFireResistanceMap = new HashMap<>();
+        splashFireResistanceMap.put(false, SPLASH_FIRE_RESISTANCE_I);
+        splashPotionMetadataMap.put(Potion.fireResistance.id, splashFireResistanceMap);
+
+        Map<Boolean, Integer> splashWaterBreathingMap = new HashMap<>();
+        splashWaterBreathingMap.put(false, SPLASH_WATER_BREATHING_I);
+        splashPotionMetadataMap.put(Potion.waterBreathing.id, splashWaterBreathingMap);
+
+        Map<Boolean, Integer> splashWeaknessMap = new HashMap<>();
+        splashWeaknessMap.put(false, SPLASH_WEAKNESS_I);
+        splashPotionMetadataMap.put(Potion.weakness.id, splashWeaknessMap);
+
+        Map<Boolean, Integer> splashLeapingMap = new HashMap<>();
+        leapingMap.put(false, SPLASH_LEAPING_I);
+        leapingMap.put(true, SPLASH_LEAPING_II);
+        splashPotionMetadataMap.put(Potion.jump.id, splashLeapingMap);
+    }
+
+
+}

--- a/shared/resources/assets/minecraft/client/lang/en_us.lang
+++ b/shared/resources/assets/minecraft/client/lang/en_us.lang
@@ -384,6 +384,21 @@ targetdisplay.roundradius=Corner Radius
 targetdisplay.background=Show Background
 targetdisplay.omitname=Omit Long Names
 
+itemcountdisplay=Item Count Display
+itemcountdisplay.desc=Quick show your items count in hud
+itemcountdisplay.round=Rounded Corners
+itemcountdisplay.roundradius=Corner Radius
+itemcountdisplay.background=Show Background
+itemcountdisplay.backgroundcolor=Background Color
+itemcountdisplay.betterfont=Clean Font
+itemcountdisplay.fontshadow=Font Shadow
+itemcountdisplay.spacing=Spacing
+itemcountdisplay.mode=Mode
+itemcountdisplay.mode.potpvp=Pot PVP
+itemcountdisplay.mode.uhc=UHC
+itemcountdisplay.mode.custom=Custom
+
+
 minimizedbobbing=No Bobbing
 minimizedbobbing.desc=Removes all screen shake
 

--- a/shared/resources/assets/minecraft/client/lang/en_us.lang
+++ b/shared/resources/assets/minecraft/client/lang/en_us.lang
@@ -220,6 +220,7 @@ autogg=AutoGG
 autogg.desc=Automatically send a custom message after a game has ended.
 autogg.servers=Servers
 autogg.servers.hypxiel=Hypxiel
+autogg.servers.kkcraft=KKCraft
 autogg.message=Custom Message
 autogg.autoplay=Auto Play
 autogg.delaytoplay=Auto Play Delay

--- a/shared/resources/assets/minecraft/client/lang/en_us.lang
+++ b/shared/resources/assets/minecraft/client/lang/en_us.lang
@@ -397,7 +397,10 @@ itemcountdisplay.mode=Mode
 itemcountdisplay.mode.potpvp=Pot PVP
 itemcountdisplay.mode.uhc=UHC
 itemcountdisplay.mode.custom=Custom
+itemcountdisplay.items=Items
 
+itemssetting.isempty=null
+itemssetting.helditem=your current held item
 
 minimizedbobbing=No Bobbing
 minimizedbobbing.desc=Removes all screen shake
@@ -458,6 +461,8 @@ coordsdisplay.limitdisplay=Y Limit Display
 coordsdisplay.limitdisplayy=Y Limit
 coordsdisplay.roundradius=Corner Radius
 coordsdisplay.background=Show Background
+
+
 
 modslist=Mod List
 modslist.desc=Show enabled modules

--- a/shared/resources/assets/minecraft/client/lang/zh_cn.lang
+++ b/shared/resources/assets/minecraft/client/lang/zh_cn.lang
@@ -386,6 +386,20 @@ targetdisplay.roundradius=圆角半径
 targetdisplay.background=背景
 targetdisplay.omitname=省略过长的名字
 
+itemcountdisplay=物品数量
+itemcountdisplay.desc=便捷的展示你的物品数量
+itemcountdisplay.round=背景圆角
+itemcountdisplay.roundradius=圆角半径
+itemcountdisplay.background=背景
+itemcountdisplay.backgroundcolor=背景颜色
+itemcountdisplay.betterfont=更好的字体
+itemcountdisplay.fontshadow=字体阴影
+itemcountdisplay.spacing=间距
+itemcountdisplay.mode=模式
+itemcountdisplay.mode.potpvp=Pot PVP
+itemcountdisplay.mode.uhc=UHC
+itemcountdisplay.mode.custom=自定义
+
 minimizedbobbing=最小摇晃
 minimizedbobbing.desc=停止全局的摇晃
 

--- a/shared/resources/assets/minecraft/client/lang/zh_cn.lang
+++ b/shared/resources/assets/minecraft/client/lang/zh_cn.lang
@@ -222,6 +222,7 @@ autogg=自动GG
 autogg.desc=游戏结束后自动地在发送你自定义的消息
 autogg.servers=服务器列表
 autogg.servers.hypxiel=Hypxiel
+autogg.servers.kkcraft=KKCraft
 autogg.message=自定义消息
 autogg.autoplay=自动重开
 autogg.delaytoplay=自动重开延迟

--- a/shared/resources/assets/minecraft/client/lang/zh_cn.lang
+++ b/shared/resources/assets/minecraft/client/lang/zh_cn.lang
@@ -400,6 +400,11 @@ itemcountdisplay.mode.potpvp=Pot PVP
 itemcountdisplay.mode.uhc=UHC
 itemcountdisplay.mode.custom=自定义
 
+itemcountdisplay.items=物品
+
+itemssetting.isempty=空的
+itemssetting.helditem=你当前手持的物品
+
 minimizedbobbing=最小摇晃
 minimizedbobbing.desc=停止全局的摇晃
 

--- a/v1.8.9/src/main/java/top/fpsmaster/forge/mixin/MixinLayerCape.java
+++ b/v1.8.9/src/main/java/top/fpsmaster/forge/mixin/MixinLayerCape.java
@@ -32,9 +32,13 @@ public abstract class MixinLayerCape implements LayerRenderer<AbstractClientPlay
     @Final
     private RenderPlayer playerRenderer;
 
-    private static final int SEGMENTS = 16;
+    @Unique
+    private static final int SEGMENTS = 18;
+    @Unique
     private static final float CAPE_WIDTH = 0.6F;
-    private static final float CAPE_LENGTH = 0.96F;
+    @Unique
+    private static final float CAPE_LENGTH = 1.08F;
+    @Unique
     private static final float CAPE_DEPTH = 0.06F;
 
     @Inject(method = "doRenderLayer", at = @At("HEAD"), cancellable = true)
@@ -73,17 +77,16 @@ public abstract class MixinLayerCape implements LayerRenderer<AbstractClientPlay
             applySegmentTransform(poseStack, player, partialTicks, segment);
 
             Matrix4f currentMatrix = poseStack.last().pose;
-            float yOffsetTop = segment * segmentLength;
-            float yOffsetBottom = (segment + 1) * segmentLength;
+            float yOffsetTop = (segment - 1) * segmentLength;
+            float yOffsetBottom = (segment) * segmentLength;
+
 
             if (prevMatrix != null) {
                 renderCapeSegment(buffer, prevMatrix, currentMatrix, yOffsetTop, yOffsetBottom, segment);
             }
-
             if (segment == 0) {
                 renderTopSegment(buffer, currentMatrix);
             }
-
             prevMatrix = currentMatrix;
             poseStack.popPose();
         }
@@ -94,7 +97,7 @@ public abstract class MixinLayerCape implements LayerRenderer<AbstractClientPlay
 
     @Unique
     private void applySegmentTransform(PoseStack poseStack, AbstractClientPlayer player, float partialTicks, int segment) {
-        poseStack.translate(0.0, 0.0, 0.125);
+        poseStack.translate(0.0, 0.0, 0.175);
 
         // 计算玩家运动差值
         double motionX = interpolate(partialTicks, player.prevChasingPosX, player.chasingPosX) -


### PR DESCRIPTION
# 功能完善 
1. 完善`歌词`缩放功能 
2. 添加KKCraft服务器的`AutoGG`功能
3. 添加`物品多选Setting`，适配`物品计数`组件
   > `物品多选Setting` 适配Config，能够良好正确的保存至配置文件中
   >  物品的配置为 id + | + metadata这样可以正确的获取信息，同时保证IO读写的速率与正确性

4. 添加物品工具类`ItemsUtil`，更便捷的操作`Item`
# 问题修复
> 有待商榷，希望FPSMaster团队能给出良好的解决方案
1. 修复披风撕裂问题
2. 延长披风长度，使披风长度与原版保持一致
# 新的组件
1. 添加`物品计数`组件,用户可以通过菜单选择适合自己的物品计数展示
   * 如 PotPVP，UHC和自定义
   * 自定义状态下，玩家可以通过当前手持物品添加至菜单中，并能实时展示当前物品数量
   > 物品数量展示包含药水等不可叠加的物品，计数是总计数，即为你背包中所有同类物品的总数
   > 组件同样添加了用户自定义的设置，包括间距等

鉴于当前FPSMaster作者暂停更新，本PR也将会等待作者恢复更新后一同合并，感谢FPSMaster团队能够接受开源贡献者的PR，希望FPSMasterTeam更加强大
